### PR TITLE
Fix an issue detecting which version of the chrono library to use ref…

### DIFF
--- a/websocketpp/common/asio.hpp
+++ b/websocketpp/common/asio.hpp
@@ -101,9 +101,19 @@ namespace lib {
             bool is_neg(T duration) {
                 return duration.count() < 0;
             }
-            inline lib::chrono::milliseconds milliseconds(long duration) {
-                return lib::chrono::milliseconds(duration);
-            }
+
+            // If boost believes it has std::chrono available it will use it
+            // so we should also use it for things that relate to boost, even
+            // if the library would otherwise use boost::chrono.
+            #if defined(BOOST_ASIO_HAS_STD_CHRONO)
+                inline std::chrono::milliseconds milliseconds(long duration) {
+                    return std::chrono::milliseconds(duration);
+                }
+            #else
+                inline lib::chrono::milliseconds milliseconds(long duration) {
+                    return lib::chrono::milliseconds(duration);
+                }
+            #endif
         #else
             // Using boost::asio <1.49 we pretend a deadline timer is a steady
             // timer and wrap the negative detection and duration conversion


### PR DESCRIPTION
…erences #512

If we are using Boost for Asio, the
websocketpp::lib::asio::milliseconds function should return a chrono
milliseconds object using whatever chrono library boost is using.

Boost does its own autodetection of the std::chrono library and prefers
it over boost::chrono when available. This change checks which chrono
library boost is using and uses that. Otherwise it falls back to the
websocketpp default.

Creating a new branch with this commit on top of 0.7, to compile with VS2015.
